### PR TITLE
Fixing checkbox and radio button label text in Calendar

### DIFF
--- a/style.css
+++ b/style.css
@@ -14989,4 +14989,10 @@ a.featured-perspective__link.uni-click-tracker:focus {
 	bottom: 97px;
 	left: -4px;
 }
+
+/* Fix radio button and checkbox colours in Calendar dialogs */
+[role="dialog"] label,
+[role="dialog"] label * {
+    color: inherit;
+}
 }


### PR DESCRIPTION
In the "Out of office" section in the new event dialog, checkboxes and radio buttons don't inherit text color as they have specific classes that overwrite other color rules. This just fixes that.

### Before
<img width="510" alt="Screen Shot 2021-10-01 at 12 05 25" src="https://user-images.githubusercontent.com/12708007/135563161-6be29ff4-9bdc-425a-a1fe-4f68ba84d86a.png">

### After
<img width="526" alt="Screen Shot 2021-10-01 at 12 06 50" src="https://user-images.githubusercontent.com/12708007/135563183-26b75f45-92b0-4581-b9c8-05a6fa44b208.png">
