### PR TITLE
Added CSS rules to work with google review snippets

### DIFF
--- a/google-dark-theme.user.css
+++ b/google-dark-theme.user.css
@@ -3084,6 +3084,12 @@ html:not(.XkWAb):not([class="w50Hl"]):not([class="hMukDb"]):not(html[stylus-ifra
 		background-color: var(--bg-transparent-dark-4);
 		color: var(--white-54);
 	}
+	.hgKElc {
+		color: var(--white-10);
+	}
+	.hgKElc b {
+		color: var(--white-10)!important;
+	}
 	.w7HGmc {
 		background-color: var(--bg-dark-12);
 	}


### PR DESCRIPTION
Before it looked like this:
![image](https://user-images.githubusercontent.com/27069993/223015743-4cbe3b9a-5919-421a-a349-acdcde7a368b.png)
Now it looks like this:
![image](https://user-images.githubusercontent.com/27069993/223015795-f54c780d-b195-4ddb-8046-1b8d0d79b463.png)
